### PR TITLE
Bugfixes + border configuration + basic deathmatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## BBU Reloaded (WIP)
-Last updated: 11/2/2021
+Last updated: 12/17/2024
 
 This project represents a Minecraft Plugin for a tournament that I used to host called BBU (discord linked at the
 bottom). The plans for this plugin are currently still in progress, I'd like to make it as customizable/easy to modify

--- a/src/main/java/me/imoltres/bbu/BBU.java
+++ b/src/main/java/me/imoltres/bbu/BBU.java
@@ -1,6 +1,5 @@
 package me.imoltres.bbu;
 
-import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import lombok.Getter;
 import me.imoltres.bbu.commands.GameCommand;
 import me.imoltres.bbu.commands.main.TrackPositionCommand;
@@ -29,7 +28,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.zip.GZIPOutputStream;
 
 /**
@@ -162,7 +160,6 @@ public class BBU extends JavaPlugin {
     }
 
 
-
     /**
      * Saves the team config and cleans up all player scoreboards, stops any ongoing tasks
      */
@@ -249,7 +246,7 @@ public class BBU extends JavaPlugin {
 
     /**
      * Write the default schematic(s)
-     * 
+     * <p>
      * - cage.schem
      */
     private void writeDefaultSchems() {

--- a/src/main/java/me/imoltres/bbu/BBU.java
+++ b/src/main/java/me/imoltres/bbu/BBU.java
@@ -7,15 +7,18 @@ import me.imoltres.bbu.commands.team.TeamPosCommand;
 import me.imoltres.bbu.controllers.CageController;
 import me.imoltres.bbu.controllers.PlayerController;
 import me.imoltres.bbu.controllers.TeamController;
-import me.imoltres.bbu.data.BBUTeamColour;
+import me.imoltres.bbu.data.BBUTeamColor;
 import me.imoltres.bbu.game.Game;
+import me.imoltres.bbu.game.ShrinkPhase;
 import me.imoltres.bbu.listeners.*;
 import me.imoltres.bbu.nametags.NametagAdapterImpl;
 import me.imoltres.bbu.scoreboard.BBUScoreboard;
 import me.imoltres.bbu.utils.CC;
 import me.imoltres.bbu.utils.command.Command;
 import me.imoltres.bbu.utils.command.CommandFramework;
+import me.imoltres.bbu.utils.config.MainConfig;
 import me.imoltres.bbu.utils.config.type.BasicConfigurationFile;
+import me.imoltres.bbu.utils.json.GsonFactory;
 import me.imoltres.bbu.utils.menu.MenuListener;
 import me.imoltres.bbu.utils.nametag.NametagHandler;
 import org.bukkit.Bukkit;
@@ -27,6 +30,8 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Objects;
 import java.util.zip.GZIPOutputStream;
 
@@ -109,6 +114,19 @@ public class BBU extends JavaPlugin {
         messagesConfig = new BasicConfigurationFile(this, "messages");
         nerfsConfig = new BasicConfigurationFile(this, "nerfs");
         teamSpawnsConfig = new BasicConfigurationFile(this, new File("world"), "teamSpawns", false);
+
+        //print shrink phases
+        Bukkit.getConsoleSender().sendMessage(CC.translate("&aParsed shrink phases:"));
+        // get the shrink phases
+        // [ { size: x, length: y } .. ]
+        var shrinkPhases = MainConfig.BORDER_PHASES;
+        var i = 0;
+        for (LinkedHashMap<String, Integer> phaseObj : shrinkPhases) {
+            var phase = new ShrinkPhase(phaseObj.get("size"), phaseObj.get("length"));
+            Bukkit.getConsoleSender().sendMessage(CC.translate("&a[" + ++i  + "] Size: " + phase.getSize() + " Length: " + phase.getLength()));
+        }
+
+        Bukkit.getConsoleSender().sendMessage(CC.translate("Actual config value: " + GsonFactory.getPrettyGson().toJson(shrinkPhases)));
 
         schemesFolder = new File(getDataFolder(), "schematics");
 
@@ -213,10 +231,10 @@ public class BBU extends JavaPlugin {
     }
 
     /**
-     * Sets up all the teams according to the {@link me.imoltres.bbu.data.BBUTeamColour} class
+     * Sets up all the teams according to the {@link me.imoltres.bbu.data.BBUTeamColor} class
      */
     private void setupTeams() {
-        for (BBUTeamColour colour : BBUTeamColour.getEntries()) {
+        for (BBUTeamColor colour : BBUTeamColor.getEntries()) {
             Bukkit.getConsoleSender().sendMessage(
                     CC.translate(
                             "&aTeam '&" + colour.getChatColor().getChar() + colour.name() + "&a' created " +

--- a/src/main/java/me/imoltres/bbu/commands/DebugCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/DebugCommand.kt
@@ -3,18 +3,14 @@ package me.imoltres.bbu.commands
 import me.imoltres.bbu.BBU
 import me.imoltres.bbu.game.GameState
 import me.imoltres.bbu.utils.CC
-import me.imoltres.bbu.utils.item.ItemConstants
 import me.imoltres.bbu.utils.command.CommandArgs
 import me.imoltres.bbu.utils.command.CommandInfo
-import me.imoltres.bbu.utils.command.Completer
 import me.imoltres.bbu.utils.command.SubCommand
+import me.imoltres.bbu.utils.item.ItemConstants
 import net.kyori.adventure.title.Title
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
-import org.bukkit.util.StringUtil
-import java.util.*
-import java.util.stream.Collectors
 
 @CommandInfo(
     name = "bbu.debug",
@@ -35,6 +31,7 @@ class DebugCommand : SubCommand {
                     ItemConstants.TEAM_BEACON,
                     "team beacon"
                 )
+
                 "givetracker" -> giveItem(
                     sender,
                     Bukkit.getPlayer(args[1]),

--- a/src/main/java/me/imoltres/bbu/commands/DebugCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/DebugCommand.kt
@@ -50,7 +50,7 @@ class DebugCommand : SubCommand {
     private fun updateState(sender: Player, input: String) {
         try {
             val state = GameState.valueOf(input.uppercase())
-            BBU.getInstance().game.thread.tick = state.tick * 20
+            BBU.getInstance().game.thread.tick = state.startTime * 20
             sender.sendMessage(CC.translate("&aUpdated game state to " + input.uppercase()))
         } catch (e: Exception) {
             e.printStackTrace()

--- a/src/main/java/me/imoltres/bbu/commands/GameCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/GameCommand.kt
@@ -126,6 +126,7 @@ class GameCommand : Command {
                                     GameState.entries.map { it.name.uppercase() }
                                 )
                             }
+
                             else -> {
                                 options.addAll(
                                     Bukkit.getOnlinePlayers().stream().map(Player::getName).collect(Collectors.toSet())
@@ -143,6 +144,7 @@ class GameCommand : Command {
                         options.add("true")
                         options.add("false")
                     }
+
                     "jointeam" -> {
                         for (team in BBU.getInstance().teamController.allTeams) {
                             options.add(team.colour.name)

--- a/src/main/java/me/imoltres/bbu/commands/main/BuildModeCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/main/BuildModeCommand.kt
@@ -1,6 +1,7 @@
 package me.imoltres.bbu.commands.main
 
 import me.imoltres.bbu.BBU
+import me.imoltres.bbu.utils.CC
 import me.imoltres.bbu.utils.command.CommandArgs
 import me.imoltres.bbu.utils.command.CommandInfo
 import me.imoltres.bbu.utils.command.SubCommand
@@ -17,6 +18,18 @@ class BuildModeCommand : SubCommand {
     override fun execute(cmd: CommandArgs) {
         val player = cmd.getSender<Player>()
         val bbuPlayer = BBU.getInstance().playerController.getPlayer(player.uniqueId)
-        bbuPlayer.build = true
+        bbuPlayer.build = !bbuPlayer.build
+
+        if (bbuPlayer.build) {
+            player.isFlying = true
+            player.allowFlight = true
+            player.sendMessage(CC.translate("&7Build mode &aenabled&7."))
+
+        } else {
+            player.isFlying = false
+            player.allowFlight = false
+            player.sendMessage(CC.translate("&7Build mode &cdisabled&7."))
+
+        }
     }
 }

--- a/src/main/java/me/imoltres/bbu/commands/main/SetLobbySpawnCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/main/SetLobbySpawnCommand.kt
@@ -2,10 +2,10 @@ package me.imoltres.bbu.commands.main
 
 import me.imoltres.bbu.BBU
 import me.imoltres.bbu.utils.CC
-import me.imoltres.bbu.utils.json.GsonFactory
 import me.imoltres.bbu.utils.command.CommandArgs
 import me.imoltres.bbu.utils.command.CommandInfo
 import me.imoltres.bbu.utils.command.SubCommand
+import me.imoltres.bbu.utils.json.GsonFactory
 import me.imoltres.bbu.utils.world.WorldPosition
 import org.bukkit.entity.Player
 

--- a/src/main/java/me/imoltres/bbu/commands/main/SetLobbySpawnCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/main/SetLobbySpawnCommand.kt
@@ -5,6 +5,7 @@ import me.imoltres.bbu.utils.CC
 import me.imoltres.bbu.utils.command.CommandArgs
 import me.imoltres.bbu.utils.command.CommandInfo
 import me.imoltres.bbu.utils.command.SubCommand
+import me.imoltres.bbu.utils.config.MainConfig
 import me.imoltres.bbu.utils.json.GsonFactory
 import me.imoltres.bbu.utils.world.WorldPosition
 import org.bukkit.entity.Player
@@ -29,5 +30,7 @@ class SetLobbySpawnCommand : SubCommand {
 
         BBU.getInstance().mainConfig.configuration.save(BBU.getInstance().mainConfig.file)
         player.sendMessage(CC.translate("&aSaved main config."))
+
+        MainConfig.reload()
     }
 }

--- a/src/main/java/me/imoltres/bbu/commands/player/PlayerCommands.kt
+++ b/src/main/java/me/imoltres/bbu/commands/player/PlayerCommands.kt
@@ -1,7 +1,7 @@
 package me.imoltres.bbu.commands.player
 
 import me.imoltres.bbu.BBU
-import me.imoltres.bbu.data.BBUTeamColour
+import me.imoltres.bbu.data.BBUTeamColor
 import me.imoltres.bbu.data.player.BBUPlayer
 import me.imoltres.bbu.utils.CC
 import me.imoltres.bbu.utils.command.CommandArgs
@@ -47,9 +47,9 @@ class PlayerCommands : SubCommand {
                     return
                 }
 
-                val colour: BBUTeamColour
+                val colour: BBUTeamColor
                 try {
-                    colour = BBUTeamColour.valueOf(args[2].uppercase())
+                    colour = BBUTeamColor.valueOf(args[2].uppercase())
                 } catch (e: Exception) {
                     sender.sendMessage(CC.translate("&cSpecify a *valid* team."))
                     return

--- a/src/main/java/me/imoltres/bbu/commands/team/TeamCommands.kt
+++ b/src/main/java/me/imoltres/bbu/commands/team/TeamCommands.kt
@@ -1,7 +1,7 @@
 package me.imoltres.bbu.commands.team
 
 import me.imoltres.bbu.BBU
-import me.imoltres.bbu.data.BBUTeamColour
+import me.imoltres.bbu.data.BBUTeamColor
 import me.imoltres.bbu.utils.CC
 import me.imoltres.bbu.utils.command.CommandArgs
 import me.imoltres.bbu.utils.command.CommandInfo
@@ -24,9 +24,9 @@ class TeamCommands : SubCommand {
             return
         }
 
-        val colour: BBUTeamColour
+        val colour: BBUTeamColor
         try {
-            colour = BBUTeamColour.valueOf(args[0].uppercase())
+            colour = BBUTeamColor.valueOf(args[0].uppercase())
         } catch (e: Exception) {
             sender.sendMessage(CC.translate("&cSpecify a *valid* team."))
             return

--- a/src/main/java/me/imoltres/bbu/commands/team/TeamPosCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/team/TeamPosCommand.kt
@@ -11,8 +11,6 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.event.HoverEvent
 import net.kyori.adventure.text.format.NamedTextColor
-import net.kyori.adventure.text.format.TextDecoration
-import org.bukkit.Location
 import org.bukkit.entity.Player
 
 @CommandInfo(
@@ -45,8 +43,18 @@ class TeamPosCommand : Command {
                 .append(
                     Component.text(location)
                         .color(NamedTextColor.AQUA)
-                        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/trackposition $location true"))
-                        .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, CC.translate("&7Click me to track!")))
+                        .clickEvent(
+                            ClickEvent.clickEvent(
+                                ClickEvent.Action.RUN_COMMAND,
+                                "/trackposition $location true"
+                            )
+                        )
+                        .hoverEvent(
+                            HoverEvent.hoverEvent(
+                                HoverEvent.Action.SHOW_TEXT,
+                                CC.translate("&7Click me to track!")
+                            )
+                        )
                 )
                 .append(Component.text("\n"))
                 .build()
@@ -62,7 +70,6 @@ class TeamPosCommand : Command {
     override fun tabCompleter(cmd: CommandArgs?): MutableList<String> {
         return arrayListOf()
     }
-
 
 
 }

--- a/src/main/java/me/imoltres/bbu/commands/team/TeamPosCommand.kt
+++ b/src/main/java/me/imoltres/bbu/commands/team/TeamPosCommand.kt
@@ -56,7 +56,6 @@ class TeamPosCommand : Command {
                             )
                         )
                 )
-                .append(Component.text("\n"))
                 .build()
 
             player.sendMessage(component)

--- a/src/main/java/me/imoltres/bbu/controllers/CageController.kt
+++ b/src/main/java/me/imoltres/bbu/controllers/CageController.kt
@@ -14,9 +14,7 @@ import org.bukkit.Material
 import org.bukkit.World
 import java.io.File
 import java.io.IOException
-import java.util.*
 import java.util.concurrent.ExecutionException
-import kotlin.collections.HashMap
 
 /**
  * Controls all the cages

--- a/src/main/java/me/imoltres/bbu/controllers/CageController.kt
+++ b/src/main/java/me/imoltres/bbu/controllers/CageController.kt
@@ -188,11 +188,7 @@ class CageController(private val plugin: BBU) {
     private fun loadChunkAt(world: World, x: Int, z: Int) {
         // loads the chunk
         println("Loading chunk at $x, $z")
-        world.getChunkAtAsyncUrgently(x shr 4, z shr 4).thenAccept { chunk ->
-            if (!chunk.isLoaded) {
-                chunk.load()
-            }
-        }.get()
+        world.loadChunk(x shr 4, z shr 4)
         println("Loaded chunk at $x, $z")
     }
 

--- a/src/main/java/me/imoltres/bbu/controllers/CageController.kt
+++ b/src/main/java/me/imoltres/bbu/controllers/CageController.kt
@@ -188,7 +188,17 @@ class CageController(private val plugin: BBU) {
     private fun loadChunkAt(world: World, x: Int, z: Int) {
         // loads the chunk
         println("Loading chunk at $x, $z")
-        world.loadChunk(x shr 4, z shr 4)
+
+        val chunkX = x shr 4
+        val chunkZ = z shr 4
+
+        // load the chunks 6x6 around the chunk
+        for (i in -3..3) {
+            for (j in -3..3) {
+                world.loadChunk(chunkX + i, chunkZ + j, true)
+            }
+        }
+
         println("Loaded chunk at $x, $z")
     }
 

--- a/src/main/java/me/imoltres/bbu/controllers/TeamController.java
+++ b/src/main/java/me/imoltres/bbu/controllers/TeamController.java
@@ -3,7 +3,7 @@ package me.imoltres.bbu.controllers;
 import com.google.common.collect.ImmutableList;
 import lombok.RequiredArgsConstructor;
 import me.imoltres.bbu.BBU;
-import me.imoltres.bbu.data.BBUTeamColour;
+import me.imoltres.bbu.data.BBUTeamColor;
 import me.imoltres.bbu.data.player.BBUPlayer;
 import me.imoltres.bbu.data.team.BBUTeam;
 import me.imoltres.bbu.utils.world.WorldPosition;
@@ -30,7 +30,7 @@ public class TeamController {
      * @param colour colour of the team
      * @return if it was successful
      */
-    public boolean createTeam(BBUTeamColour colour) {
+    public boolean createTeam(BBUTeamColor colour) {
         return teams.add(new BBUTeam(colour));
     }
 
@@ -40,7 +40,7 @@ public class TeamController {
      * @param colour colour of the team
      * @return if it was successful
      */
-    public boolean deleteTeam(BBUTeamColour colour) {
+    public boolean deleteTeam(BBUTeamColor colour) {
         return teams.remove(getTeam(colour));
     }
 
@@ -60,7 +60,7 @@ public class TeamController {
      * @param colour colour of the team
      * @return BBUTeam
      */
-    public BBUTeam getTeam(BBUTeamColour colour) {
+    public BBUTeam getTeam(BBUTeamColor colour) {
         return teams.stream().filter(team -> team.getColour() == colour).findFirst().orElse(null);
     }
 

--- a/src/main/java/me/imoltres/bbu/data/BBUTeamColor.kt
+++ b/src/main/java/me/imoltres/bbu/data/BBUTeamColor.kt
@@ -5,7 +5,7 @@ import org.bukkit.ChatColor
 /**
  * Enum holding all the team colours
  */
-enum class BBUTeamColour(val chatColor: ChatColor) {
+enum class BBUTeamColor(val chatColor: ChatColor) {
     RED(ChatColor.RED),
     GREEN(ChatColor.GREEN),
     BLUE(ChatColor.BLUE),

--- a/src/main/java/me/imoltres/bbu/data/player/BBUPlayer.kt
+++ b/src/main/java/me/imoltres/bbu/data/player/BBUPlayer.kt
@@ -144,7 +144,8 @@ class BBUPlayer(val uniqueId: UUID, val name: String) {
 
     private fun showFirework(deathLocation: Location) {
         val loc = deathLocation.toHighestLocation()
-        val firework: Firework = loc.world.spawnEntity(loc.clone().add(0.0, 50.0, 0.0), EntityType.FIREWORK_ROCKET) as Firework
+        val firework: Firework =
+            loc.world.spawnEntity(loc.clone().add(0.0, 50.0, 0.0), EntityType.FIREWORK_ROCKET) as Firework
         val fireworkMeta: FireworkMeta = firework.fireworkMeta
 
         // Set the type of the firework
@@ -181,7 +182,7 @@ class BBUPlayer(val uniqueId: UUID, val name: String) {
 
         if (MainConfig.SPECTATE_AFTER_DEATH) {
             // put player in spectator mode where they can either only spectate their teammates if they have any, otherwise they spectate freely
-            player?.gameMode = org.bukkit.GameMode.SPECTATOR
+            player?.gameMode = GameMode.SPECTATOR
             spectatingActionMsgThread = Bukkit.getScheduler().runTaskTimer(BBU.getInstance(), Runnable {
                 val str = "&7To switch teammates &eLEFT CLICK &7or &eRIGHT CLICK."
                 player?.sendActionBar(

--- a/src/main/java/me/imoltres/bbu/data/player/BBUPlayer.kt
+++ b/src/main/java/me/imoltres/bbu/data/player/BBUPlayer.kt
@@ -42,7 +42,7 @@ class BBUPlayer(val uniqueId: UUID, val name: String) {
     var eliminated = false
     var switchingSpectator = false
     var spectatingTeam: BBUTeam? = null
-    var spectatingActionMsgThread: BukkitTask? = null
+    private var spectatingActionMsgThread: BukkitTask? = null
 
     var scoreboard: BBUScoreboardAdapter? = null
         set(value) {

--- a/src/main/java/me/imoltres/bbu/data/team/BBUCage.kt
+++ b/src/main/java/me/imoltres/bbu/data/team/BBUCage.kt
@@ -13,9 +13,6 @@ class BBUCage(
 ) {
 
     val spawnPosition: WorldPosition = spawnPosition
-        get() {
-            return field
-        }
 
     override fun toString(): String {
         return "BBUCage {team=" + team.colour.name + ", cuboid=" + cuboid.toString() + ", spawnPos=" + spawnPosition.toString() + "}"

--- a/src/main/java/me/imoltres/bbu/data/team/BBUTeam.kt
+++ b/src/main/java/me/imoltres/bbu/data/team/BBUTeam.kt
@@ -1,7 +1,7 @@
 package me.imoltres.bbu.data.team
 
 import me.imoltres.bbu.BBU
-import me.imoltres.bbu.data.BBUTeamColour
+import me.imoltres.bbu.data.BBUTeamColor
 import me.imoltres.bbu.data.player.BBUPlayer
 import me.imoltres.bbu.game.events.team.BBUTeamModificationEvent
 import me.imoltres.bbu.utils.CC
@@ -16,7 +16,7 @@ import java.util.concurrent.ThreadLocalRandom
 /**
  * Represents a team within the game
  */
-class BBUTeam(val colour: BBUTeamColour) {
+class BBUTeam(val colour: BBUTeamColor) {
     var cage: BBUCage? = null
         set(value) {
             val event = BBUTeamModificationEvent(
@@ -138,6 +138,10 @@ class BBUTeam(val colour: BBUTeamColour) {
             beacon!!.toWorldPosition(BBU.getInstance().game.overworld.name).block.type = Material.AIR
             beacon = null
         }
+    }
+
+    fun delete() {
+        BBU.getInstance().teamController.deleteTeam(this)
     }
 
     /**

--- a/src/main/java/me/imoltres/bbu/game/Game.kt
+++ b/src/main/java/me/imoltres/bbu/game/Game.kt
@@ -183,7 +183,7 @@ class Game {
         //Get spawn world
         spawnWorld = WorldCreator("bbuSpawnWorld").generator(EmptyChunkGenerator()).createWorld()!!
 
-        worlds = arrayOf(overworld, nether, end, spawnWorld);
+        worlds = arrayOf(overworld, nether, end, spawnWorld)
         for (world in worlds) {
             world.loadChunk(0, 0)
             world.worldBorder.setCenter(0.0, 0.0)

--- a/src/main/java/me/imoltres/bbu/game/GameState.kt
+++ b/src/main/java/me/imoltres/bbu/game/GameState.kt
@@ -2,31 +2,31 @@ package me.imoltres.bbu.game
 
 /**
  * Game state
+ * @param startTime a time (in seconds) that the game state should start at (if it's -1, then it's a condition based or a manually set state)
+ * @param display the display name of the game state
  */
-enum class GameState(val startsAfterTick: Int, val display: String?) {
+enum class GameState(val startTime: Int, val display: String?) {
     LOBBY(-1, null),
     PRE_GAME(-1, null),
     GRACE(0, null),
-    PVP(1800, "PVP"),
-    PVP_BORDER_SHRINK(3600, "Border"),
+    PVP(1800, "PVP"), // 1800 seconds = 30 minutes, switch to PVP after 30 minutes of grace
+    PVP_BORDER_SHRINK(3600, "Border"), // 3600 seconds = 1 hour, border will start shrinking 30 minutes after pvp
+    DEATHMATCH(5400, "Deathmatch"), // 5400 seconds = 1 hour 30 minutes, will switch to deathmatch 30min after border shrink
     POST_GAME(-1, null)
     ;
-
-    val tick: Int
-        get() = if (startsAfterTick > 0) values()[ordinal - 1].startsAfterTick + startsAfterTick else startsAfterTick
 
     /**
      * @return the next game state after the current one
      */
     operator fun next(): GameState? {
-        return if (this != POST_GAME) values()[ordinal + 1] else null
+        return if (this != POST_GAME) entries[ordinal + 1] else null
     }
 
     /**
      * @return is the game state allowing pvp
      */
     fun isPvp(): Boolean {
-        return this == PVP || this == PVP_BORDER_SHRINK || this == POST_GAME
+        return this == PVP || this == PVP_BORDER_SHRINK || this == DEATHMATCH || this == POST_GAME
     }
 
     /**
@@ -42,12 +42,14 @@ enum class GameState(val startsAfterTick: Int, val display: String?) {
          * @return the gamestate (nullable)
          */
         fun getGameStateFromTick(tick: Int): GameState? {
-            val secondTick = tick / 20
+            val secondTick = tick / 20 // convert minecraft ticks to seconds
 
             var s: GameState? = null
-            for (state in values()) {
-                if (state.startsAfterTick == -1) continue
-                if (secondTick >= state.tick) {
+            for (state in entries) {
+                if (state.startTime == -1) continue
+
+                // check if we've passed the start time of the state
+                if (secondTick >= state.startTime) {
                     s = state
                 }
             }

--- a/src/main/java/me/imoltres/bbu/game/ShrinkPhase.kt
+++ b/src/main/java/me/imoltres/bbu/game/ShrinkPhase.kt
@@ -1,0 +1,3 @@
+package me.imoltres.bbu.game
+
+data class ShrinkPhase(val size: Int, val length: Int)

--- a/src/main/java/me/imoltres/bbu/game/threads/GameThread.kt
+++ b/src/main/java/me/imoltres/bbu/game/threads/GameThread.kt
@@ -114,9 +114,9 @@ class GameThread(val game: Game) : BukkitRunnable() {
                     shrinkBorder(shrinkPhase)
                     shrinking = !shrinking
 
-                    // shrinking till shrinkPhase.length + 5 minutes
+                    // shrinking till shrinkPhase.length + 10 minutes
                     // in ticks
-                    shrinkingTime = 20 * (shrinkPhase.length + 600) // 5 minutes
+                    shrinkingTime = 20 * (shrinkPhase.length + 600) // 10 minutes
                 }
             }
 
@@ -169,12 +169,12 @@ class GameThread(val game: Game) : BukkitRunnable() {
 
     /**
      * Shrink the border globally
-     * @param seconds seconds to shrink it for
+     * @param shrinkPhase the phase to shrink the border to
      */
     private fun shrinkBorder(shrinkPhase: ShrinkPhase) {
         PlayerUtils.broadcastTitle(
             "&cBorder Shrinking!",
-            "&7${shrinkPhase.size} in " + DateUtils.readableTime(BigDecimal(shrinkPhase.length.toLong()))
+            "&7${shrinkPhase.size} in" + DateUtils.readableTime(BigDecimal(shrinkPhase.length.toLong()))
         )
 
         Bukkit.getScheduler().runTask(BBU.getInstance()) { ->

--- a/src/main/java/me/imoltres/bbu/game/threads/GameThread.kt
+++ b/src/main/java/me/imoltres/bbu/game/threads/GameThread.kt
@@ -4,14 +4,18 @@ import me.imoltres.bbu.BBU
 import me.imoltres.bbu.data.team.BBUTeam
 import me.imoltres.bbu.game.Game
 import me.imoltres.bbu.game.GameState
+import me.imoltres.bbu.game.ShrinkPhase
 import me.imoltres.bbu.utils.CC
+import me.imoltres.bbu.utils.config.MainConfig
 import me.imoltres.bbu.utils.general.DateUtils
 import me.imoltres.bbu.utils.general.PlayerUtils
+import me.imoltres.bbu.utils.item.ItemConstants
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.scheduler.BukkitRunnable
 import java.math.BigDecimal
 import java.util.*
+import kotlin.math.roundToInt
 
 /**
  * Main game thread loop, swaps the game states, checks the teams, and ticks the game.
@@ -20,15 +24,14 @@ class GameThread(val game: Game) : BukkitRunnable() {
 
     var tick: Int = 0
 
-    //TODO: replace with some sort of deathmatch feature
-    private val shrinkTo = 75.0
-
     private var shrinking = false
     private var pvp = false
 
     var started = false
 
     val teamCheckQueue = LinkedList<BBUTeam>()
+
+    var shrinkingTime = 0
 
     /**
      * Game loop
@@ -50,8 +53,20 @@ class GameThread(val game: Game) : BukkitRunnable() {
                 if (!pvp) {
                     PlayerUtils.broadcastTitle(
                         "&cPvP is now enabled.",
-                        "&7" + DateUtils.readableTime(BigDecimal(GameState.PVP_BORDER_SHRINK.startsAfterTick - (tick / 20))) + " till border shrink."
+                        "&7" + DateUtils.readableTime(BigDecimal(GameState.PVP_BORDER_SHRINK.startTime - (tick / 20))) + " till border shrink."
                     )
+
+                    // take away the beacon if they haven't placed it yet
+                    for (team in game.getTeams(false)) {
+                        for (player in team.players) {
+                            val bukkitPlayer = Bukkit.getPlayer(player.uniqueId) ?: continue
+
+                            if (bukkitPlayer.inventory.contains(ItemConstants.TEAM_BEACON)) {
+                                bukkitPlayer.inventory.removeItemAnySlot(ItemConstants.TEAM_BEACON)
+                                bukkitPlayer.sendMessage(CC.translate("&cYou have lost your beacon because you didn't place it in time."))
+                            }
+                        }
+                    }
 
                     pvp = !pvp
                 }
@@ -78,10 +93,30 @@ class GameThread(val game: Game) : BukkitRunnable() {
             }
 
             GameState.PVP_BORDER_SHRINK -> {
+                if (shrinkingTime > 0) {
+                    shrinkingTime--
+                    game.border = game.overworld.worldBorder.size.roundToInt()
+                } else {
+                    shrinking = false
+                }
+
                 if (!shrinking) {
                     val border = game.border
-                    shrinkBorder(getBorderShrinkTime(border))
+                    val shrinkPhase = getBorderShrinkPhase(border)
+
+                    if (shrinkPhase == null) {
+                        // switch to deathmatch
+                        game.gameState = GameState.DEATHMATCH
+                        return
+                    }
+
+
+                    shrinkBorder(shrinkPhase)
                     shrinking = !shrinking
+
+                    // shrinking till shrinkPhase.length + 5 minutes
+                    // in ticks
+                    shrinkingTime = 20 * (shrinkPhase.length + 600) // 5 minutes
                 }
             }
 
@@ -108,23 +143,43 @@ class GameThread(val game: Game) : BukkitRunnable() {
      *
      * based on the size of the border
      */
-    private fun getBorderShrinkTime(border: Int): Int {
-        return (border / 6) * 60
+    private fun getBorderShrinkPhase(border: Int): ShrinkPhase? {
+        // get the shrink phases
+        // [ { size: x, length: y } .. ]
+        val shrinkPhases = MainConfig.BORDER_PHASES
+
+        // find the phase that the border is in
+        var maxLength = 0
+        var maxSize = 0
+        for (phaseObj in shrinkPhases) {
+            val phase = ShrinkPhase(phaseObj["size"] as Int, phaseObj["length"] as Int)
+            // find the max size that the border is in
+            if (phase.size in (maxSize + 1)..<border) {
+                maxSize = phase.size
+                maxLength = phase.length
+            }
+        }
+
+        if (maxSize == border) {
+            return null
+        }
+
+        return ShrinkPhase(maxSize, maxLength)
     }
 
     /**
      * Shrink the border globally
      * @param seconds seconds to shrink it for
      */
-    private fun shrinkBorder(seconds: Int) {
+    private fun shrinkBorder(shrinkPhase: ShrinkPhase) {
         PlayerUtils.broadcastTitle(
-            "&cShrinking Border to $shrinkTo",
-            "&7in" + DateUtils.readableTime(BigDecimal(seconds))
+            "&cBorder Shrinking!",
+            "&7${shrinkPhase.size} in " + DateUtils.readableTime(BigDecimal(shrinkPhase.length.toLong()))
         )
 
         Bukkit.getScheduler().runTask(BBU.getInstance()) { ->
             for (world in Bukkit.getWorlds()) {
-                world.worldBorder.setSize(shrinkTo, seconds.toLong())
+                world.worldBorder.setSize(shrinkPhase.size.toDouble(), shrinkPhase.length.toLong())
             }
         }
     }

--- a/src/main/java/me/imoltres/bbu/listeners/BeaconListener.kt
+++ b/src/main/java/me/imoltres/bbu/listeners/BeaconListener.kt
@@ -49,8 +49,15 @@ class BeaconListener : Listener {
         //is bbu beacon :D
         val player = e.player
         val team = BBU.getInstance().teamController.getTeam(player) ?: return
-        if (BBU.getInstance().game.gameState != GameState.GRACE)
+        if (BBU.getInstance().game.gameState != GameState.GRACE) {
+            // only allow beacon placement in grace
+            e.isCancelled = true
+
+            // take away the beacon!
+            player.inventory.removeItem(ItemConstants.TEAM_BEACON)
+            player.sendMessage(CC.translate("&cYou have lost your beacon because you didn't place it during the grace period."))
             return
+        }
 
         val event = BBUPlaceBeaconEvent(
             team,

--- a/src/main/java/me/imoltres/bbu/listeners/DamageListener.kt
+++ b/src/main/java/me/imoltres/bbu/listeners/DamageListener.kt
@@ -29,6 +29,7 @@ class DamageListener : Listener {
             return
         }
 
+        // cancel damage if the game is not in pvp mode
         e.isCancelled = !BBU.getInstance().game.gameState.isPvp()
     }
 
@@ -52,11 +53,10 @@ class DamageListener : Listener {
         }
 
         if (damager == null) {
-            println("Damager is null, ignoring damage event")
             return
         }
 
-        var bbuDamager: BBUPlayer? = BBU.getInstance().playerController.getPlayer(damager.uniqueId)
+        val bbuDamager: BBUPlayer? = BBU.getInstance().playerController.getPlayer(damager.uniqueId)
 
         //if pvp is disabled, cancel the damage
         if (!MainConfig.FRIENDLY_FIRE) {

--- a/src/main/java/me/imoltres/bbu/listeners/JoinListener.kt
+++ b/src/main/java/me/imoltres/bbu/listeners/JoinListener.kt
@@ -49,7 +49,7 @@ class JoinListener : Listener {
         }
 
         val player = e.player
-        val bbuPlayer = BBU.getInstance().playerController.getPlayer(player.uniqueId);
+        val bbuPlayer = BBU.getInstance().playerController.getPlayer(player.uniqueId)
 
         e.joinMessage(CC.translate("&7[&a+&7] &7" + e.player.name))
 

--- a/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
+++ b/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
@@ -23,7 +23,7 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
 
         if (game.gameState.next() != null) {
             val tick = game.thread.tick / 20
-            val timeTill = DateUtils.readableTime(BigDecimal(game.gameState.next()!!.startsAfterTick - tick))
+            val timeTill = DateUtils.readableTime(BigDecimal(game.gameState.next()!!.startTime - tick))
 
             when (game.gameState) {
                 GameState.GRACE, GameState.PVP -> lines.add(
@@ -35,11 +35,21 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
                 )
 
                 GameState.PVP_BORDER_SHRINK -> {
+                    val timeTillShrink = DateUtils.readableTime(BigDecimal((game.thread.shrinkingTime / 20) - tick))
+
                     lines.add(
                         String.format(
                             "&b%s&f: %.1f",
                             game.gameState.display,
                             game.overworld.worldBorder.size
+                        )
+                    )
+
+                    lines.add(
+                        String.format(
+                            "&b%s&f:%s",
+                            "Next shrink",
+                            timeTillShrink
                         )
                     )
                 }

--- a/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
+++ b/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
@@ -34,26 +34,6 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
                     )
                 )
 
-                GameState.PVP_BORDER_SHRINK -> {
-                    val timeTillShrink = DateUtils.readableTime(BigDecimal((game.thread.shrinkingTime / 20) - tick))
-
-                    lines.add(
-                        String.format(
-                            "&b%s&f: %.1f",
-                            game.gameState.display,
-                            game.overworld.worldBorder.size
-                        )
-                    )
-
-                    lines.add(
-                        String.format(
-                            "&b%s&f:%s",
-                            "Next shrink",
-                            timeTillShrink
-                        )
-                    )
-                }
-
                 else -> {}
             }
         }
@@ -69,6 +49,29 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
         }
 
         lines.add("")
+
+        if (game.gameState == GameState.PVP_BORDER_SHRINK) {
+            val timeTillShrink = DateUtils.readableTime(BigDecimal((game.thread.shrinkingTime / 20)))
+
+            lines.add(
+                String.format(
+                    "&b%s&f: %.1f",
+                    game.gameState.display,
+                    game.overworld.worldBorder.size
+                )
+            )
+
+            lines.add(
+                String.format(
+                    "&b%s&f:%s",
+                    "Next shrink",
+                    timeTillShrink
+                )
+            )
+
+            lines.add("")
+        }
+
 
         for (team in BBU.getInstance().teamController.allTeams) {
             val name = CC.capitalize(team.colour.name.lowercase())

--- a/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
+++ b/src/main/java/me/imoltres/bbu/scoreboard/impl/MainScoreboard.kt
@@ -33,6 +33,7 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
                         timeTill
                     )
                 )
+
                 GameState.PVP_BORDER_SHRINK -> {
                     lines.add(
                         String.format(
@@ -42,6 +43,7 @@ class MainScoreboard(player: Player) : BBUScoreboardAdapter(1, player) {
                         )
                     )
                 }
+
                 else -> {}
             }
         }

--- a/src/main/java/me/imoltres/bbu/utils/command/CommandFramework.java
+++ b/src/main/java/me/imoltres/bbu/utils/command/CommandFramework.java
@@ -135,7 +135,8 @@ public class CommandFramework implements TabExecutor {
                         completions.put(command, new AbstractMap.SimpleEntry<>(m, instance));
                     }
                 }
-            } catch (NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+            } catch (NoSuchMethodException | InvocationTargetException | InstantiationException |
+                     IllegalAccessException e) {
                 e.printStackTrace();
             }
         }

--- a/src/main/java/me/imoltres/bbu/utils/config/AbstractConfigurationFile.java
+++ b/src/main/java/me/imoltres/bbu/utils/config/AbstractConfigurationFile.java
@@ -76,5 +76,5 @@ public abstract class AbstractConfigurationFile {
      */
     public abstract List<String> getStringList(String var1);
 
-
+    public abstract void reloadConfig();
 }

--- a/src/main/java/me/imoltres/bbu/utils/config/MainConfig.java
+++ b/src/main/java/me/imoltres/bbu/utils/config/MainConfig.java
@@ -2,20 +2,47 @@ package me.imoltres.bbu.utils.config;
 
 import me.imoltres.bbu.BBU;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
 /**
  * Configuration properties imported from config.yml
  */
 public class MainConfig<T> extends ConfigGetter<T> {
 
-    public static int BORDER = new MainConfig<Integer>("border").get();
-    public static String LOBBY_SPAWN = new MainConfig<String>("lobby-spawn").get();
+    public static int BORDER_SIZE = new MainConfig<Integer>("border.size").get();
+    public static ArrayList<LinkedHashMap<String, Integer>> BORDER_PHASES = new MainConfig<ArrayList<LinkedHashMap<String, Integer>>>("border.shrink-phases").get();
+
+    public static boolean DEATHMATCH_ENABLED = new MainConfig<Boolean>("deathmatch.enabled").get();
+    public static int DEATHMATCH_TIME = new MainConfig<Integer>("deathmatch.time").get();
 
     public static boolean SPECTATE_AFTER_DEATH = new MainConfig<Boolean>("spectate-after-death").get();
 
     public static boolean FRIENDLY_FIRE = new MainConfig<Boolean>("friendly-fire").get();
 
+    public static String LOBBY_SPAWN = new MainConfig<String>("lobby-spawn").get();
+    public static String DEATHMATCH_SPAWN = new MainConfig<String>("deathmatch.spawn").get();
+
     MainConfig(String path) {
         super(BBU.getInstance().getMainConfig(), path);
+    }
+
+    public static void reload() {
+        BBU.getInstance().getMainConfig().reloadConfig();
+
+        //i really wish there was a better way to do this
+        BORDER_SIZE = new MainConfig<Integer>("border.size").get();
+        BORDER_PHASES = new MainConfig<ArrayList<LinkedHashMap<String, Integer>>>("border.shrink-phases").get();
+
+        DEATHMATCH_ENABLED = new MainConfig<Boolean>("deathmatch.enabled").get();
+        DEATHMATCH_TIME = new MainConfig<Integer>("deathmatch.time").get();
+
+        SPECTATE_AFTER_DEATH = new MainConfig<Boolean>("spectate-after-death").get();
+
+        FRIENDLY_FIRE = new MainConfig<Boolean>("friendly-fire").get();
+
+        LOBBY_SPAWN = new MainConfig<String>("lobby-spawn").get();
+        DEATHMATCH_SPAWN = new MainConfig<String>("deathmatch.spawn").get();
     }
 
 }

--- a/src/main/java/me/imoltres/bbu/utils/config/Messages.java
+++ b/src/main/java/me/imoltres/bbu/utils/config/Messages.java
@@ -1,8 +1,6 @@
 package me.imoltres.bbu.utils.config;
 
-import lombok.RequiredArgsConstructor;
 import me.imoltres.bbu.BBU;
-import me.imoltres.bbu.utils.config.type.BasicConfigurationFile;
 
 /**
  * Messages imported from the messages.yml config

--- a/src/main/java/me/imoltres/bbu/utils/config/type/BasicConfigurationFile.java
+++ b/src/main/java/me/imoltres/bbu/utils/config/type/BasicConfigurationFile.java
@@ -52,7 +52,7 @@ public class BasicConfigurationFile extends AbstractConfigurationFile {
 
     /**
      * Initialise an instance with a plugin, name
-     * 
+     * <p>
      * doesn't overwrite by default.
      *
      * @param plugin bukkit plugin

--- a/src/main/java/me/imoltres/bbu/utils/config/type/BasicConfigurationFile.java
+++ b/src/main/java/me/imoltres/bbu/utils/config/type/BasicConfigurationFile.java
@@ -1,7 +1,9 @@
 package me.imoltres.bbu.utils.config.type;
 
 import lombok.Getter;
+import me.imoltres.bbu.utils.CC;
 import me.imoltres.bbu.utils.config.AbstractConfigurationFile;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -13,7 +15,7 @@ public class BasicConfigurationFile extends AbstractConfigurationFile {
     @Getter
     private final File file;
     @Getter
-    private final YamlConfiguration configuration;
+    private YamlConfiguration configuration;
 
     /**
      * Initialise an instance with a plugin, name, and if
@@ -89,6 +91,16 @@ public class BasicConfigurationFile extends AbstractConfigurationFile {
 
     public List<String> getStringList(String path) {
         return this.configuration.contains(path) ? this.configuration.getStringList(path) : null;
+    }
+
+    @Override
+    public void reloadConfig() {
+        Bukkit.getConsoleSender().sendMessage(CC.translate("&aReloading " + this.file.getName() + "..."));
+        try {
+            this.configuration = YamlConfiguration.loadConfiguration(this.file);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     private void saveResource(String resourcePath, File outDir, boolean replace) {

--- a/src/main/java/me/imoltres/bbu/utils/general/BlockUtils.kt
+++ b/src/main/java/me/imoltres/bbu/utils/general/BlockUtils.kt
@@ -1,9 +1,6 @@
 package me.imoltres.bbu.utils.general
 
 import me.imoltres.bbu.BBU
-import me.imoltres.bbu.utils.world.Position
-import me.imoltres.bbu.utils.world.WorldPosition
-import org.bukkit.Location
 import org.bukkit.Material
 import org.bukkit.block.Block
 import org.bukkit.block.BlockFace
@@ -16,12 +13,12 @@ class BlockUtils {
 
     companion object {
         val faces = arrayOf(
-                BlockFace.NORTH,
-                BlockFace.EAST,
-                BlockFace.SOUTH,
-                BlockFace.WEST,
-                BlockFace.UP,
-                BlockFace.DOWN
+            BlockFace.NORTH,
+            BlockFace.EAST,
+            BlockFace.SOUTH,
+            BlockFace.WEST,
+            BlockFace.UP,
+            BlockFace.DOWN
         )
 
         /**

--- a/src/main/java/me/imoltres/bbu/utils/item/ItemConstants.java
+++ b/src/main/java/me/imoltres/bbu/utils/item/ItemConstants.java
@@ -10,9 +10,9 @@ public class ItemConstants {
 
     /**
      * ###Tracking compass item represented as a constant
-     * 
+     * <p>
      * Allows for identification and separation of a normal compass and a tracking compass.
-     *
+     * <p>
      * Used to track players or any team.
      * Can also be used to track any coordinates that a teammate or ally provides. (command undecided, but likely `/track x y z`)
      */
@@ -25,9 +25,9 @@ public class ItemConstants {
 
     /**
      * ###Team Beacon item represented as a constant
-     *
+     * <p>
      * Allows for identification and separation of a beacon and a "team beacon".
-     *
+     * <p>
      * Used for pre-pvp events when the player wants to place their team's beacon down to
      * allow their team to respawn.
      */

--- a/src/main/java/me/imoltres/bbu/utils/menu/Menu.java
+++ b/src/main/java/me/imoltres/bbu/utils/menu/Menu.java
@@ -7,7 +7,6 @@ import me.imoltres.bbu.utils.CC;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 

--- a/src/main/java/me/imoltres/bbu/utils/menu/button/ConfirmationButton.java
+++ b/src/main/java/me/imoltres/bbu/utils/menu/button/ConfirmationButton.java
@@ -7,13 +7,11 @@ import me.imoltres.bbu.utils.item.ItemBuilder;
 import me.imoltres.bbu.utils.menu.Button;
 import me.imoltres.bbu.utils.menu.Menu;
 import me.imoltres.bbu.utils.sound.SoundBuilder;
-import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 
 @AllArgsConstructor
 public class ConfirmationButton extends Button {

--- a/src/main/java/me/imoltres/bbu/utils/menu/button/Filler.java
+++ b/src/main/java/me/imoltres/bbu/utils/menu/button/Filler.java
@@ -20,6 +20,10 @@ public class Filler extends Button {
 
     @Override
     public ItemStack getButtonItem(Player player) {
+        if (filler == Material.AIR) {
+            return new ItemStack(Material.AIR);
+        }
+
         return new ItemBuilder(filler).name("").build();
     }
 }

--- a/src/main/java/me/imoltres/bbu/utils/nametag/NametagBoard.java
+++ b/src/main/java/me/imoltres/bbu/utils/nametag/NametagBoard.java
@@ -12,11 +12,11 @@ public class NametagBoard {
     @Getter
     private final UUID uuid;
     @Getter
-    private Set<String> bufferedTeams = new HashSet<>();
+    private final Set<String> bufferedTeams = new HashSet<>();
     @Getter
-    private Map<String, List<String>> bufferedPlayers = new HashMap<>();
+    private final Map<String, List<String>> bufferedPlayers = new HashMap<>();
     @Getter
-    private NametagHandler handler;
+    private final NametagHandler handler;
 
     public NametagBoard(Player player, NametagHandler handler) {
         this.uuid = player.getUniqueId();

--- a/src/main/java/me/imoltres/bbu/utils/nametag/NametagListeners.java
+++ b/src/main/java/me/imoltres/bbu/utils/nametag/NametagListeners.java
@@ -10,7 +10,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 @Getter
 public class NametagListeners implements Listener {
 
-    private NametagHandler handler;
+    private final NametagHandler handler;
 
     public NametagListeners(NametagHandler handler) {
         this.handler = handler;

--- a/src/main/java/me/imoltres/bbu/utils/schematic/SchematicParser.java
+++ b/src/main/java/me/imoltres/bbu/utils/schematic/SchematicParser.java
@@ -14,6 +14,7 @@ public class SchematicParser {
 
     /**
      * Very barebones schematic parser, only parses the blocks and returns their positions and materials.
+     *
      * @param schematic
      * @return HashMap of positions (relative to the origin) and materials
      */

--- a/src/main/java/me/imoltres/bbu/utils/sound/SoundBuilder.java
+++ b/src/main/java/me/imoltres/bbu/utils/sound/SoundBuilder.java
@@ -1,6 +1,5 @@
 package me.imoltres.bbu.utils.sound;
 
-import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Sound;
@@ -60,7 +59,7 @@ public class SoundBuilder {
      * @param players Players to play sound to
      */
     public void play(Player... players) {
-        for(Player player : players) {
+        for (Player player : players) {
             player.playSound(player.getLocation(), sound, volume, pitch);
         }
     }
@@ -69,7 +68,7 @@ public class SoundBuilder {
      * Broadcast a sound to all players
      */
     public void broadcast() {
-        for(Player player : Bukkit.getOnlinePlayers()) {
+        for (Player player : Bukkit.getOnlinePlayers()) {
             play(player);
         }
     }

--- a/src/main/java/me/imoltres/bbu/utils/world/ChunkCuboid.java
+++ b/src/main/java/me/imoltres/bbu/utils/world/ChunkCuboid.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.io.IOException;
+import java.util.Objects;
 
 @Getter
 @AllArgsConstructor
@@ -74,7 +75,7 @@ public class ChunkCuboid {
 
         ChunkCuboid that = (ChunkCuboid) o;
 
-        return x == that.x && z == that.z && (world != null ? world.equals(that.world) : that.world == null);
+        return x == that.x && z == that.z && (Objects.equals(world, that.world));
     }
 
     @Override

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,24 @@
-border: 1000
-lobby-spawn: ""
+border:
+  size: 1000
+  shrink-phases:
+    # phase 1
+    -  size: 500 # size of border after 1st shrink
+       length: 450 # time it takes to shrink to this size in seconds
+       # 450 seconds = 7.5 minutes
+
+    # phase 2
+    -  size: 100 # size of border after 2nd shrink
+       length: 900 # time it takes to shrink to this size
+       # 900 seconds = 15 minutes
+
+deathmatch:
+  enabled: true
+  time: 900 # time in seconds after border is DONE shrinking
+  spawn: "" # location of deathmatch spawn
 
 spectate-after-death: true
 
 #allow teammates to hit eachother
 friendly-fire: true
+
+lobby-spawn: ""


### PR DESCRIPTION
- Fix scoreboard not erasing blank lines on shrink
- Add border shrink phases
- Started on deathmatch (gotta finish border stuff first)
- Remove beacon from inventory after grace if not placed
- Keep the cage chunk loaded for performance when tping (Likely also going to load chunks around too)
- Create a lobby spawn if it's not already there on first run
- adjust spacing on scoreboard + messages, fix timing for border shrink
- fix filler trying to name air (spoiler: air is unnameable)