### PR TITLE
Fix seed usage in world regeneration and update version to 0.2-BETA

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 val main by extra("me.imoltres.bbu.BBU")
-val ver by extra("0.1-BETA")
+val ver by extra("0.2-BETA")
 val apiVersion by extra("1.21.11")
 val kotlinVersion by extra("2.3.10")
 

--- a/src/main/java/me/imoltres/bbu/game/Game.kt
+++ b/src/main/java/me/imoltres/bbu/game/Game.kt
@@ -403,6 +403,7 @@ class Game {
 
         val creator = WorldCreator(world.name)
             .environment(world.environment)
+            .seed(seed)
             .type(WorldType.NORMAL)
 
         for (player in world.players) {


### PR DESCRIPTION
* World creation now uses the provided `seed` value when initializing the `WorldCreator` in the `Game` class (`src/main/java/me/imoltres/bbu/game/Game.kt`).